### PR TITLE
RUN-5810: Launch Selenium tests with clean temporary profile

### DIFF
--- a/RunOpenFin.bat
+++ b/RunOpenFin.bat
@@ -18,6 +18,9 @@ SET debuggingPort=0
  IF "%opt%" == "--config" (
     SET startupURL=%2
  )
+ IF "%opt%" == "--user-data-dir" (
+    SET userDataDir=%2
+ )
 
 
  SHIFT & GOTO loop  
@@ -32,6 +35,6 @@ SET openfinLocation=%LocalAppData%\OpenFin
 C:
 
 cd %openfinLocation%
-OpenFinRVM.exe --config=%startupURL% --runtime-arguments="--remote-debugging-port=%debuggingPort%"
+OpenFinRVM.exe --config=%startupURL% --runtime-arguments="--remote-debugging-port=%debuggingPort% --user-data-dir=%userDataDir%"
 
 ENDLOCAL

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "express": "^4.15.3",
+    "fs-extra": "^8.1.0",
     "openfin-launcher": "^1.3.12"
   }
 }

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,6 +1,12 @@
 /* global fin, browser */
 const spawn = require('child_process').spawn
 const fork = require('child_process').fork
+// fs.remove doesn't delete non-empty dirs in node < 12.10 so we need fs-extra
+const fs = require('fs-extra')
+const os = require('os')
+const path = require('path')
+
+var temp_profile = "";
 
 exports.config = {
   specs: [
@@ -13,7 +19,8 @@ exports.config = {
     chromeOptions: {
       extensions: [],
       binary: 'RunOpenFin.bat',
-      args: ['--config=http://localhost:3000/testingapp.json']
+      args: ['--config=http://localhost:3000/testingapp.json',
+             `--user-data-dir=${temp_profile}`]
     }
   }],
   sync: true,
@@ -38,6 +45,20 @@ exports.config = {
   after: function (result, capabilities, specs) {
     browser.execute(() => {
       fin.desktop.Application.getCurrent().close()
+    })
+  },
+  beforeSuite : function (suite) {
+    random_string = 'xxxxxxxx-xxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0,
+    v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+  temp_profile = path.join(os.tmpdir(), `of-temp-profile-${random_string}`);
+  fs.mkdirSync(temp_profile, 0744);
+  },
+  afterSuite: function (suite) {
+    fs.remove(temp_profile, err => {
+      if (err) return console.error(err)
     })
   }
 }


### PR DESCRIPTION
With current implementation of webniar-automated-integration-tests
tests use profile from default location which can lead to unreliable
results and - in case of corrupted profile - to tests failures.
With this change every test suite uses clean temporary profile
which is being deleted after test suite finishes.